### PR TITLE
Fix sed arguments

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -76,7 +76,7 @@ http {
 end
 
 release["default_process_types"] = {
-  "web" => "sed -i'' -e \"s/%PORT%/$PORT/g\" #{app_groonga_httpd_conf} && groonga-httpd",
+  "web" => "sed -i '' -e \"s/%PORT%/$PORT/g\" #{app_groonga_httpd_conf} && groonga-httpd",
 }
 
 puts(release.to_yaml)


### PR DESCRIPTION
`-i'' -e` is equal to `-i -e`.
When using bsd sed, `-i -e` means extension is `-e`.
And `-i ''` means no backup.